### PR TITLE
Fixed stroke width exception on Android

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.0.1
 apiversion: 3
 architectures: armeabi-v7a x86
 description: Provides a paint surface user interface view.

--- a/android/src/ti/modules/titanium/paint/PaintViewProxy.java
+++ b/android/src/ti/modules/titanium/paint/PaintViewProxy.java
@@ -33,8 +33,9 @@ public class PaintViewProxy extends TiViewProxy {
 
 	@Kroll.setProperty
 	@Kroll.method
-	public void setStrokeWidth(Float width) {
-		paintView.setStrokeWidth(width);
+	public void setStrokeWidth(Integer width) {
+		Float strokeWidth = (float)width;
+		paintView.setStrokeWidth(strokeWidth);
 	}
 
 	@Kroll.setProperty


### PR DESCRIPTION
Setting stroke width after creation of the paint view on Android
terminated the app with an exception since the module was expecting a
float and received an integer instead.
This fix casts the integer to a float before continuing.