### PR TITLE
fix(android): allow white

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.0
+version: 5.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Provides a paint surface user interface view.

--- a/android/src/ti/modules/titanium/paint/UIPaintView.java
+++ b/android/src/ti/modules/titanium/paint/UIPaintView.java
@@ -29,7 +29,7 @@ public class UIPaintView extends TiUIView {
 	public PaintView tiPaintView;
 	private KrollDict props;
 	private Boolean eraseState = false;
-	private int currentColor = -1;
+	private int currentColor = -999999999;
 	private int alphaState = -1;
 	private Float oldWidth = -1.0f;
 
@@ -47,7 +47,7 @@ public class UIPaintView extends TiUIView {
 	}
 
 	private void setPaintOptions() {
-		if (currentColor == -1) {
+		if (currentColor == -999999999) {
 			currentColor = (props.containsKeyAndNotNull("strokeColor")) ? TiConvert.toColor(props, "strokeColor") : TiConvert.toColor("black");
 		}
 
@@ -83,7 +83,7 @@ public class UIPaintView extends TiUIView {
 		eraseState = toggle;
 		if (eraseState) {
 			tiPaint.setColor(TiConvert.toColor("black"));
-						tiPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
+			tiPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
 		} else {
 			tiPaint.setXfermode(null);
 		}


### PR DESCRIPTION
Turns out `-1` is white :smile: And the the check didn't allow the user to set full white (`rgb(255,255,254)` worked).

[ti.paint-android-5.0.1.zip](https://github.com/tidev/ti.paint/files/9150385/ti.paint-android-5.0.1.zip)

