### PR TITLE
fix(android): Image loading, setters, example

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.1
+version: 5.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Provides a paint surface user interface view.

--- a/android/src/ti/modules/titanium/paint/PaintViewProxy.java
+++ b/android/src/ti/modules/titanium/paint/PaintViewProxy.java
@@ -34,33 +34,32 @@ public class PaintViewProxy extends TiViewProxy {
 	}
 
 	@Kroll.setProperty
-	@Kroll.method
 	public void setStrokeWidth(Object width) {
 		paintView.setStrokeWidth(TiConvert.toFloat(width));
 	}
 
 	@Kroll.setProperty
-	@Kroll.method
 	public void setStrokeColor(String color) {
 		paintView.setStrokeColor(color);
 	}
 
 	@Kroll.setProperty
-	@Kroll.method
 	public void setEraseMode(Boolean toggle) {
 		paintView.setEraseMode(toggle);
 	}
 
 	@Kroll.setProperty
-	@Kroll.method
 	public void setStrokeAlpha(int alpha) {
 		paintView.setStrokeAlpha(alpha);
 	}
 
 	@Kroll.setProperty
-	@Kroll.method
 	public void setImage(String imagePath) {
-		paintView.setImage(imagePath);
+		if (!TiApplication.isUIThread()) {
+			TiMessenger.sendBlockingMainMessage(handler.obtainMessage(MSG_LOAD));
+		} else {
+			paintView.setImage(imagePath);
+		}
 	}
 
 	@Kroll.method
@@ -100,12 +99,19 @@ public class PaintViewProxy extends TiViewProxy {
 	}
 
 	private static final int MSG_CLEAR = 60000;
+	private static final int MSG_LOAD = 60001;
 	private final Handler handler = new Handler(TiMessenger.getMainMessenger().getLooper(), new Handler.Callback() {
 		public boolean handleMessage(@NotNull Message msg) {
 			switch (msg.what) {
 				case MSG_CLEAR: {
 					AsyncResult result = (AsyncResult) msg.obj;
 					paintView.clear();
+					result.setResult(null);
+					return true;
+				}
+				case MSG_LOAD: {
+					AsyncResult result = (AsyncResult) msg.obj;
+					paintView.setImage(result.getResult().toString());
 					result.setResult(null);
 					return true;
 				}

--- a/android/src/ti/modules/titanium/paint/PathPaint.java
+++ b/android/src/ti/modules/titanium/paint/PathPaint.java
@@ -6,6 +6,7 @@ import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
 
 public class PathPaint {
@@ -20,7 +21,7 @@ public class PathPaint {
 
 	public Paint getPaint() {
 			if (isErease) {
-					myPaint.setColor(TiConvert.toColor("black"));
+					myPaint.setColor(TiConvert.toColor("black", TiApplication.getAppCurrentActivity()));
 					myPaint.setAlpha(0xFF);
 					myPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
 					myPaint.setColor(Color.TRANSPARENT);
@@ -51,7 +52,7 @@ public class PathPaint {
 			myPaint = new Paint();
 			myPaint.setAntiAlias(true);
 			myPaint.setDither(true);
-			myPaint.setColor(TiConvert.toColor("black"));
+			myPaint.setColor(TiConvert.toColor("black", TiApplication.getAppCurrentActivity()));
 			myPaint.setStyle(Paint.Style.STROKE);
 			myPaint.setStrokeJoin(Paint.Join.ROUND);
 			myPaint.setStrokeCap(Paint.Cap.ROUND);

--- a/example/app.js
+++ b/example/app.js
@@ -17,6 +17,7 @@ var paintView = Paint.createPaintView({
 win.add(paintView);
 
 var buttonStrokeWidth = Ti.UI.createButton({
+	height: 40,
 	left: 10,
 	bottom: 10,
 	right: 10,
@@ -29,6 +30,7 @@ buttonStrokeWidth.addEventListener('click', function(e) {
 win.add(buttonStrokeWidth);
 
 var buttonStrokeColorRed = Ti.UI.createButton({
+	height: 40,
 	bottom: 100,
 	left: 10,
 	title: 'Red'
@@ -37,6 +39,7 @@ buttonStrokeColorRed.addEventListener('click', function() {
 	paintView.strokeColor = 'red';
 });
 var buttonStrokeColorGreen = Ti.UI.createButton({
+	height: 40,
 	bottom: 70,
 	left: 10,
 	title: 'Green'
@@ -45,6 +48,7 @@ buttonStrokeColorGreen.addEventListener('click', function() {
 	paintView.strokeColor = '#0f0';
 });
 var buttonStrokeColorBlue = Ti.UI.createButton({
+	height: 40,
 	bottom: 40,
 	left: 10,
 	title: 'Blue'
@@ -57,6 +61,7 @@ win.add(buttonStrokeColorGreen);
 win.add(buttonStrokeColorBlue);
 
 var clear = Ti.UI.createButton({
+	height: 40,
 	bottom: 40,
 	left: 100,
 	title: 'Clear'
@@ -68,6 +73,7 @@ win.add(clear);
 
 if (OS_ANDROID) {
 	var undo = Ti.UI.createButton({
+		height: 40,
 		bottom: 70,
 		left: 100,
 		title: 'undo'
@@ -77,6 +83,7 @@ if (OS_ANDROID) {
 	});
 	win.add(undo);
 	var redo = Ti.UI.createButton({
+		height: 40,
 		bottom: 100,
 		left: 100,
 		title: 'redo'
@@ -87,7 +94,27 @@ if (OS_ANDROID) {
 	win.add(redo);
 }
 
+var isSaved = false;
+var buttonLoadSave = Ti.UI.createButton({
+	height: 40,
+	bottom: 100,
+	right: 10,
+	title: 'Save/Load'
+});
+buttonLoadSave.addEventListener('click', function(e) {
+	var file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, "tmp.jpg");
+	if (!isSaved) {
+		paintView.toImage(function(blob) {
+			file.write(blob);
+			alert("done");
+		})
+	} else {
+		paintView.image = file.nativePath
+	}
+	isSaved = !isSaved;
+});
 var buttonStrokeAlpha = Ti.UI.createButton({
+	height: 40,
 	bottom: 70,
 	right: 10,
 	title: 'Alpha : 100%'
@@ -99,6 +126,7 @@ buttonStrokeAlpha.addEventListener('click', function(e) {
 win.add(buttonStrokeAlpha);
 
 var buttonStrokeColorEraser = Ti.UI.createButton({
+	height: 40,
 	bottom: 40,
 	right: 10,
 	title: 'Erase : Off'
@@ -108,21 +136,11 @@ buttonStrokeColorEraser.addEventListener('click', function(e) {
 	e.source.title = (paintView.eraseMode) ? 'Erase : On' : 'Erase : Off';
 });
 win.add(buttonStrokeColorEraser);
+win.add(buttonLoadSave);
 
-paintView.addEventListener('touchcancel', function(e) {
-	console.log('touchcancel event fired.');
-});
-
-paintView.addEventListener('touchend', function(e) {
-	console.log('touchend event fired.');
-});
-
-paintView.addEventListener('touchmove', function(e) {
-	console.log('touchmove event fired.');
-});
-
-paintView.addEventListener('touchstart', function(e) {
-	console.log('touchstart event fired.');
-});
+paintView.addEventListener('touchcancel', function(e) {});
+paintView.addEventListener('touchend', function(e) {});
+paintView.addEventListener('touchmove', function(e) {});
+paintView.addEventListener('touchstart', function(e) {});
 
 win.open();


### PR DESCRIPTION
* fix image loading
* some null checks
* fix toColor warnings
* only use setters instead of method + setters
* added loading/saving to the example
* emptying touchEvents so the log is not that noisy


https://user-images.githubusercontent.com/4334997/204887154-fb18f4b2-a9f4-4da3-bcfb-879ed5306201.mp4

[ti.paint-android-5.1.0.zip](https://github.com/tidev/ti.paint/files/10126492/ti.paint-android-5.1.0.zip)
